### PR TITLE
Less options paths

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,7 +15,9 @@
     "notStrictEqual": true,
     "raises": true,
     "start": true,
-    "stop": true
+    "stop": true,
+    "System": true,
+    "Promise": true
   },
 
   "curly": true,

--- a/less.js
+++ b/less.js
@@ -3,6 +3,10 @@ var lessEngine = require("less");
 
 exports.instantiate = css.instantiate;
 
+var opts = steal.config('lessOptions') || {},
+	parseOpts = opts.parse || {},
+	evalOpts = opts.eval || {};
+
 exports.translate = function(load) {
 	var pathParts = (load.address+'').split('/');
 		pathParts[pathParts.length - 1] = ''; // Remove filename
@@ -14,14 +18,16 @@ exports.translate = function(load) {
 		paths = [pathParts.join('/')];
 	}
 	return new Promise(function(resolve, reject){
-		new (lessEngine.Parser)({
-			optimization: lessEngine.optimization,
-			paths: [pathParts.join('/')]
-		}).parse(load.source, function (e, root) {
+		// defaults
+		parseOpts.paths |= [pathParts.join('/')];
+		parseOpts.optimization |= lessEngine.optimization;
+
+		var Parser = lessEngine.Parser;
+		new Parser(parseOpts).parse(load.source, function (e, root) {
 			if(e){
 				reject(e);
 			} else {
-				resolve(root.toCSS());
+				resolve(root.toCSS(evalOpts));
 			}
 		});
 	});

--- a/less.js
+++ b/less.js
@@ -3,22 +3,21 @@ var lessEngine = require("less");
 
 exports.instantiate = css.instantiate;
 
-var options = steal.config('lessOptions') || {};
-
-// default optimization value.
-options.optimization |= lessEngine.optimization;
-
 exports.translate = function(load) {
+
+	// make options private, because we may change them
+	var options = steal.extend({}, steal.config('lessOptions') || {});
+
+	// default optimization value.
+	options.optimization |= lessEngine.optimization;
 
 	// paths option is used only in node.js
 	if (typeof window === 'undefined') {
 
-		var sep = (load.address + '').indexOf('\\') > 0 ? '\\' : '/' // determine path separator
-
-		var pathParts = (load.address +'' ).split(sep);
+		var pathParts = (load.address + '').split('/');
 		pathParts[pathParts.length - 1] = ''; // Remove filename
 		// allow to have custom paths in options and add path
-		options.paths = (options.paths || []).concat(pathParts.join(sep));
+		options.paths = (options.paths || []).concat(pathParts.join('/'));
 	}
 	return new Promise(function(resolve, reject){
 

--- a/less.js
+++ b/less.js
@@ -3,9 +3,10 @@ var lessEngine = require("less");
 
 exports.instantiate = css.instantiate;
 
-var opts = steal.config('lessOptions') || {},
-	parseOpts = opts.parse || {},
-	evalOpts = opts.eval || {};
+var options = steal.config('lessOptions') || {};
+
+// default optimization value.
+options.optimization |= lessEngine.optimization;
 
 exports.translate = function(load) {
 	var pathParts = (load.address+'').split('/');
@@ -18,16 +19,14 @@ exports.translate = function(load) {
 		paths = [pathParts.join('/')];
 	}
 	return new Promise(function(resolve, reject){
-		// defaults
-		parseOpts.paths |= [pathParts.join('/')];
-		parseOpts.optimization |= lessEngine.optimization;
+		options.paths = [pathParts.join('/')];
 
 		var Parser = lessEngine.Parser;
-		new Parser(parseOpts).parse(load.source, function (e, root) {
+		new Parser(options).parse(load.source, function (e, root) {
 			if(e){
 				reject(e);
 			} else {
-				resolve(root.toCSS(evalOpts));
+				resolve(root.toCSS(options));
 			}
 		});
 	});

--- a/less.js
+++ b/less.js
@@ -9,17 +9,19 @@ var options = steal.config('lessOptions') || {};
 options.optimization |= lessEngine.optimization;
 
 exports.translate = function(load) {
-	var pathParts = (load.address+'').split('/');
-		pathParts[pathParts.length - 1] = ''; // Remove filename
 
-	var paths = [];
-	if (typeof window !== 'undefined') {
-		pathParts = (load.address+'').split('/');
+	// paths option is used only in node.js
+	if (typeof window === 'undefined') {
+
+		var sep = (load.address + '').indexOf('\\') > 0 ? '\\' : '/' // determine path separator
+
+		var pathParts = (load.address +'' ).split(sep);
 		pathParts[pathParts.length - 1] = ''; // Remove filename
-		paths = [pathParts.join('/')];
+		// allow to have custom paths in options and add path
+		options.paths = (options.paths || []).concat(pathParts.join(sep));
 	}
 	return new Promise(function(resolve, reject){
-		options.paths = [pathParts.join('/')];
+
 
 		var Parser = lessEngine.Parser;
 		new Parser(options).parse(load.source, function (e, root) {

--- a/main.js
+++ b/main.js
@@ -190,6 +190,7 @@ var makeSteal = function(System){
 	steal.parseURI = parseURI;
 	steal.joinURIs = joinURIs;
 	steal.normalize = normalize;
+	steal.extend = extend;
 
 	// System.ext = {bar: "path/to/bar"}
 	// foo.bar! -> foo.bar!path/to/bar

--- a/steal.js
+++ b/steal.js
@@ -4915,6 +4915,7 @@ var makeSteal = function(System){
 	steal.parseURI = parseURI;
 	steal.joinURIs = joinURIs;
 	steal.normalize = normalize;
+	steal.extend = extend;
 
 	// System.ext = {bar: "path/to/bar"}
 	// foo.bar! -> foo.bar!path/to/bar

--- a/steal.production.js
+++ b/steal.production.js
@@ -1,5 +1,5 @@
 /*
- *  steal v0.3.0
+ *  steal v0.4.0-pre
  *  
  *  Copyright (c) 2014 Bitovi; Licensed MIT
  */

--- a/test/config.js
+++ b/test/config.js
@@ -6,6 +6,14 @@ System.config({
 	bundle: ["foo"],
 	ext : {
 		crazy : "extensions/text"
+	},
+	lessOptions: {
+		parse: {
+			dumpLineNumbers: "comments" // default false
+		},
+		eval: {
+			strictMath: true // default false
+		}
 	}
 });
 

--- a/test/config.js
+++ b/test/config.js
@@ -8,12 +8,8 @@ System.config({
 		crazy : "extensions/text"
 	},
 	lessOptions: {
-		parse: {
-			dumpLineNumbers: "comments" // default false
-		},
-		eval: {
-			strictMath: true // default false
-		}
+		dumpLineNumbers: "comments", // default false
+		strictMath: true, // default false
 	}
 });
 

--- a/test/less_options/main.js
+++ b/test/less_options/main.js
@@ -1,0 +1,19 @@
+
+if (typeof window !== "undefined" && window.QUnit) {
+	var systemInstantiate = System.instantiate;
+
+	System.instantiate = function(load) {
+		if (load.name.indexOf("main.less") !== -1) {
+			var hasLineNumber = load.source.indexOf("line 1, input") !== -1,
+				hasStrictMath = load.source.indexOf("100%") !== -1;
+
+			QUnit.ok(hasLineNumber, "less set to dump line numbers");
+			QUnit.ok(hasStrictMath, "less set to process only maths inside un-necessary parenthesis");
+			QUnit.start();
+			removeMyself();
+		}
+		return systemInstantiate.apply(this, arguments);
+	};
+
+	steal("less_options/main.less!steal/less");
+}

--- a/test/less_options/main.js
+++ b/test/less_options/main.js
@@ -15,5 +15,5 @@ if (typeof window !== "undefined" && window.QUnit) {
 		return systemInstantiate.apply(this, arguments);
 	};
 
-	steal("less_options/main.less!steal/less");
+	steal("less_options/main.less!");
 }

--- a/test/less_options/main.less
+++ b/test/less_options/main.less
@@ -1,0 +1,4 @@
+#test {
+	width: 288px;
+	height: calc(100% - (10px  - 5px));
+}

--- a/test/less_options/site.html
+++ b/test/less_options/site.html
@@ -1,0 +1,10 @@
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+	<script type="text/javascript"
+		src='../../steal.js'
+		data-config="../config.js"
+		data-main="less_options/main"></script>
+</body>

--- a/test/test.js
+++ b/test/test.js
@@ -194,7 +194,13 @@ QUnit.config.testTimeout = 30000;
 	asyncTest("System.instantiate preventing production css bundle", function(){
 		makeIframe("production/prod-inst.html");
 	});
+
 	asyncTest("Multi mains", function(){
 		makeIframe("multi-main/dev.html");
 	});
+
+	asyncTest("set options to less plugin", function(){
+		makeIframe("less_options/site.html");
+	});
+
 })();


### PR DESCRIPTION
Added ability to have custom ```paths``` option in ```lessOptions``` (that is used only in nodejs mode). Options moved inside of ```translate``` function. Added ```steal.extend```.