### PR TITLE
Several fixes to docs theme layout.

### DIFF
--- a/theme/templates/layout.mustache
+++ b/theme/templates/layout.mustache
@@ -25,8 +25,8 @@
 		<link rel="stylesheet" type="text/css" href="./static/bundles/static.css">
 	{{/devBuild}}
 	<!--[if lt IE 9]>
-   <script type="text/javascript" src="static/html5shiv.js"></script>
-    <!--<![endif]-->
+	 <script type="text/javascript" src="static/html5shiv.js"></script>
+		<!--<![endif]-->
 </head>
 
 <body class="docs {{pageType}}">
@@ -36,35 +36,36 @@
 			<div class="logo-menu">
 				<a class="brand" href="{{urlFromConfig 'index.html'}}">StealJS</a>
 				<ul class="dropdown-menu">
-		          <li><a href="http://javascriptmvc.com">JavaScriptMVC</a></li>
-		          <li><a href="http://canjs.com">CanJS</a></li>
-		          <li><a href="http://jquerypp.com">jQuery++</a></li>
-		          <li class="active"><a href="http://stealjs.com">StealJS</a></li>
-		          <li><a href="http://funcunit.com">FuncUnit</a></li>
-		          <li><a href="http://javascriptmvc.com/docs.html#!DocumentJS">DocumentJS</a></li>
-		        </ul>
+					<li><a href="http://javascriptmvc.com">JavaScriptMVC</a></li>
+					<li><a href="http://canjs.com">CanJS</a></li>
+					<li><a href="http://jquerypp.com">jQuery++</a></li>
+					<li class="active"><a href="http://stealjs.com">StealJS</a></li>
+					<li><a href="http://funcunit.com">FuncUnit</a></li>
+					<li><a href="http://documentjs.com/">DocumentJS</a></li>
+				</ul>
 			</div>
 			<ul class="nav">
-        <li {{#ifCurrentFromConfig "index.html"}}class="active"{{/ifCurrentFromConfig}}><a href="http://stealjs.com">Home</a></li>
-        {{#ifEqual page "index"}}
-          <li><a href="{{urlFromConfig 'docs'}}/index.html">Api</a></li>
-        {{else}}
-          <li class="active"><a href="{{urlFromConfig 'docs'}}/index.html">Api</a></li>
-        {{/ifEqual}}
-	          <li class=""><a href="https://twitter.com/stealjs">Twitter</a></li>
-		      <li class=""><a href="https://github.com/bitovi/steal">GitHub</a></li>
-	        </ul>
+				<li {{#ifCurrentFromConfig "index.html"}}class="active"{{/ifCurrentFromConfig}}><a href="http://stealjs.com">Home</a></li>
+				{{#ifEqual page "index"}}
+					<li><a href="{{urlFromConfig 'docs'}}/index.html">Api</a></li>
+				{{else}}
+					<li class="active"><a href="{{urlFromConfig 'docs'}}/index.html">Api</a></li>
+				{{/ifEqual}}
+						<li class=""><a href="https://twitter.com/stealjs">Twitter</a></li>
+					<li class=""><a href="https://github.com/bitovi/steal">GitHub</a></li>
+					</ul>
 			<div class="pull-right">
 				<div class="bitovi-menu">
 					<a href="http://bitovi.com" class="bitovi icon-bits">Bitovi</a>
 					<ul class="dropdown-menu">
 						<li><a href="http://bitovi.com">Bitovi.com</a></li>
-						<li><a href="http://bitovi.com/blog/">Blog</a></li>
-						<li><a href="http://bitovi.com/consulting/">Consulting</a></li>
-						<li><a href="http://bitovi.com/training/">Training</a></li>
-						<li><a href="http://bitovi.com/open-source/">Open Source</a></li>
-						<li><a href="http://bitovi.com/people/">People</a></li>
-						<li><a href="http://bitovi.com/contact/">Contact Us</a></li>
+						<li><a href="http://bitovi.com/blog">Blog</a></li>
+						<li><a href="http://bitovi.com/development">Development</a></li>
+						<li><a href="http://bitovi.com/design">Design</a></li>
+						<li><a href="http://bitovi.com/training">Training</a></li>
+						<li><a href="http://bitovi.com/open-source">Open Source</a></li>
+						<li><a href="http://bitovi.com/about">About</a></li>
+						<li><a href="http://bitovi.com/contact">Contact Us</a></li>
 					</ul>
 				</div>
 			</div>
@@ -89,14 +90,14 @@
 		};
 
 	</script>
-	<script type='text/javascript' 
+	<script type='text/javascript'
 			data-main="static"
 	{{#staticLocation}}
 		src="{{.}}steal.js"
 	{{else}}
 		src="./static/steal.production.js"
 	{{/staticLocation}}
-	    bundles-path="bundles"
+			bundles-path="bundles"
 		></script>
 </body>
 


### PR DESCRIPTION
- Add Design link
- Fix DocumentJS link
- Rename People to About
- Rename Consulting to Development
- Use consistently tabs for indentation

Closes #295 and #296.