### PR TITLE
Remove loaded successful message

### DIFF
--- a/src/startup.js
+++ b/src/startup.js
@@ -114,11 +114,7 @@
 				return Promise.all( map(main,function(main){
 					return System["import"](main)
 				}) );
-			}).then(function(){
-				if(steal.dev) {
-					steal.dev.log("app loaded successfully")
-				}
-			}, function(error){
+			}).then(null, function(error){
 				console.log("error",error,  error.stack);
 			});
 			return appDeferred;


### PR DESCRIPTION
This gets rid of the "your app loaded successfully" message which creates noise during builds
and isn't something useful anyways, really only useful for debugging steal.